### PR TITLE
Generic compile script dependency checks.

### DIFF
--- a/2_create_sd.sh
+++ b/2_create_sd.sh
@@ -37,7 +37,7 @@ DEVICE=${1}
 
 if [ "${USE_CHROOT}" != 0 ] ; then
     # check_deps for arch-chroot on non RISC-V host
-    for DEP in arch-install-scripts qemu-user-static-bin binfmt-qemu-static ; do
+    for DEP in arch-chroot qemu-riscv64 update-binfmts ; do
         check_deps ${DEP}
     done
 fi

--- a/consts.sh
+++ b/consts.sh
@@ -32,7 +32,7 @@ export KERNEL_RELEASE='5.18.0-rc1-gcc63db754b21-dirty' # must match commit!
 export IGNORE_COMMITS=0
 
 check_deps() {
-    if ! pacman -Qi "${1}" > /dev/null ; then
+    if ! which "${1}" > /dev/null ; then
         echo "Please install '${1}'"
         exit 1
     fi


### PR DESCRIPTION
By using `which` to see if deps are installed I can compile the projects on my Ubuntu box which uses apt instead of pacman.