### PR TITLE
Enable binfmt_misc kernel support

### DIFF
--- a/1_compile.sh
+++ b/1_compile.sh
@@ -204,6 +204,8 @@ if [ ! -f "${OUT_DIR}/Image" ] || [ ! -f "${OUT_DIR}/Image.gz" ] ; then
             echo 'CONFIG_MEDIA_CONTROLLER_REQUEST_API=y' >> ${DIR}/arch/riscv/configs/nezha_defconfig
             echo 'CONFIG_V4L_MEM2MEM_DRIVERS=y' >> ${DIR}/arch/riscv/configs/nezha_defconfig
             echo 'CONFIG_VIDEO_SUNXI_CEDRUS=y' >> ${DIR}/arch/riscv/configs/nezha_defconfig
+            # enable binfmt_misc
+            echo 'CONFIG_BINFMT_MISC=y' >> ${DIR}/arch/riscv/configs/nezha_defconfig
             # debug options
             if [ $DEBUG = 'y' ]; then
                 echo 'CONFIG_DEBUG_INFO=y' >> ${DIR}/arch/riscv/configs/nezha_defconfig


### PR DESCRIPTION
Hi, thanks for this awesome project! I use this resource to create an Arch image for my MangoPi MQ-Pro. My patch allows binaries for other architectures (like x86_64 via [box64](https://github.com/ptitSeb/box64)) to be ran, directly from a shell. More info can be found [here](https://docs.kernel.org/admin-guide/binfmt-misc.html).