### PR TITLE
Update upstream references

### DIFF
--- a/1_compile.sh
+++ b/1_compile.sh
@@ -233,7 +233,7 @@ if [ ! -f "${OUT_DIR}/8723ds.ko" ]; then
     DIR='rtl8723ds'
     clean_dir ${DIR}
 
-    git clone "${SOURCE_RTL8723}"
+    git clone "${SOURCE_RTL8723}" -b "${TAG_RTL8723}"
     cd ${DIR}
     make CROSS_COMPILE="${CROSS_COMPILE}" ARCH="${ARCH}" KSRC=../linux-build -j "${NPROC}" modules || true
     cd ..

--- a/2_create_sd.sh
+++ b/2_create_sd.sh
@@ -100,9 +100,6 @@ ${SUDO} mkdir -p "${MNT}/lib/modules"
 ${SUDO} cp -a "${OUT_DIR}/modules/${KERNEL_RELEASE}" "${MNT}/lib/modules"
 ${SUDO} install -D -p -m 644 "${OUT_DIR}/8723ds.ko" "${MNT}/lib/modules/${KERNEL_RELEASE}/kernel/drivers/net/wireless/8723ds.ko"
 
-${SUDO} rm "${MNT}/lib/modules/${KERNEL_RELEASE}/build"
-${SUDO} rm "${MNT}/lib/modules/${KERNEL_RELEASE}/source"
-
 ${SUDO} depmod -a -b "${MNT}" "${KERNEL_RELEASE}"
 echo '8723ds' >>8723ds.conf
 ${SUDO} mv 8723ds.conf "${MNT}/etc/modules-load.d/"

--- a/consts.sh
+++ b/consts.sh
@@ -15,7 +15,7 @@ NPROC="$(nproc)"
 export PWD
 export NPROC
 
-export ROOT_FS='archriscv-2024-03-30.tar.zst'
+export ROOT_FS='archriscv-2025-06-12.tar.zst'
 export ROOT_FS_DL="https://archriscv.felixc.at/images/${ROOT_FS}"
 
 # select 'arch', 'defconfig'
@@ -50,18 +50,19 @@ export USE_CHROOT=1
 # use extlinux ('extlinux') or boot.scr ('script') for loading the kernel?
 export BOOT_METHOD='extlinux'
 
-export VERSION_OPENSBI='1.4'
-export VERSION_KERNEL='6.8'
+export VERSION_OPENSBI='1.7'
+export VERSION_KERNEL='6.18'
 
 export SOURCE_OPENSBI="https://github.com/riscv-software-src/opensbi/releases/download/v${VERSION_OPENSBI}/opensbi-${VERSION_OPENSBI}-rv-bin.tar.xz"
-export SOURCE_UBOOT='https://github.com/smaeul/u-boot'
+export SOURCE_UBOOT='https://github.com/MartinHerren/u-boot'
 export SOURCE_KERNEL="https://github.com/torvalds/linux/archive/refs/tags/v${VERSION_KERNEL}.tar.gz"
-export SOURCE_RTL8723='https://github.com/lwfinger/rtl8723ds.git'
+export SOURCE_RTL8723='https://github.com/amazingfate/rtl8723ds.git'
 # https://github.com/karabek/xradio
 
 # pinned commits (no notice when things change)
-export COMMIT_UBOOT='329e94f16ff84f9cf9341f8dfdff7af1b1e6ee9a' # equals d1-2022-10-31
-export TAG_UBOOT='d1-2022-10-31'
+export COMMIT_UBOOT='d35a660d5c26559a4e10e30e2780a566629c13e9' # equals d1-2022-10-31
+export TAG_UBOOT='d1-wip-python-fix'
+export TAG_RTL8723='fix-6.18'
 # use this (set to something != 0) to override the check
 export IGNORE_COMMITS=0
 export DEBUG='n'


### PR DESCRIPTION
Hello! I brushed the dust off my Mango Pi MQ-Pro and wanted to build an Arch image for it using the latest upstream versions. I had to use a fork for the RTL8723ds driver because this didn't build anymore on the latest kernel versions. I also had to use a fork for uboot. But this was because the Python version on my host system was too new. Tested on both Debian 13 and Arch.

* Update kernel to 6.18
* Update rootfs to 2025-06-12
* Update opensbi to 1.7
* Use [fork of rtl8723ds](https://github.com/amazingfate/rtl8723ds/tree/fix-6.18) driver to allow builds on newer kernel
* Use [fork of uboot](https://github.com/MartinHerren/u-boot/commits/d1-wip-python-fix/) to fix build issue on newer Python versions